### PR TITLE
Add long break settings

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -20,6 +20,8 @@
     <label>Work (min): <input type="number" id="workMinutes" min="1" value="25"></label>
     <label>Break (min): <input type="number" id="breakMinutes" min="1" value="5"></label>
     <label>Cycles: <input type="number" id="cycles" min="1" value="4"></label>
+    <label>Long break (min): <input type="number" id="longBreak" min="1" value="15"></label>
+    <label>Long break every (cycles): <input type="number" id="longBreakEvery" min="1" value="4"></label>
     <button id="saveSettings">Save</button>
     <hr>
     <button id="testSound">🔊 Test sound</button>

--- a/popup.js
+++ b/popup.js
@@ -14,12 +14,24 @@ $("reset").addEventListener("click", ()=> chrome.runtime.sendMessage({cmd:"reset
 
 /************ settings load ************/
 chrome.storage.local.get(["settings"], ({settings})=>{
-  if(settings){ $("workMinutes").value=settings.work; $("breakMinutes").value=settings.break; $("cycles").value=settings.cycles; }
+  if(settings){
+    $("workMinutes").value=settings.work;
+    $("breakMinutes").value=settings.break;
+    $("cycles").value=settings.cycles;
+    $("longBreak").value=settings.longBreak ?? 15;
+    $("longBreakEvery").value=settings.longBreakEvery ?? 4;
+  }
 });
 
 /************ save settings ************/
 $("saveSettings").addEventListener("click", ()=>{
-  const settings={ work:+$("workMinutes").value, break:+$("breakMinutes").value, cycles:+$("cycles").value };
+  const settings={
+    work:+$("workMinutes").value,
+    break:+$("breakMinutes").value,
+    cycles:+$("cycles").value,
+    longBreak:+$("longBreak").value,
+    longBreakEvery:+$("longBreakEvery").value
+  };
   chrome.storage.local.set({settings}, ()=>{
     chrome.runtime.sendMessage({cmd:"settingsUpdated"});
     alert("Saved! New values apply on next reset/start.");

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,5 +1,5 @@
 /***** defaults *****/
-const DEF = { work: 25, break: 5, cycles: 4 };
+const DEF = { work: 25, break: 5, cycles: 4, longBreak: 15, longBreakEvery: 4 };
 let SET   = { ...DEF };
 
 /***** state *****/
@@ -115,7 +115,9 @@ chrome.runtime.onMessage.addListener((msg, _sender, reply) => {
         cycle: st.cycle,
         totalCycles: st.total,
         minutes: Math.floor(rem / 60000),
-        seconds: Math.floor((rem % 60000) / 1000)
+        seconds: Math.floor((rem % 60000) / 1000),
+        longBreak: SET.longBreak,
+        longBreakEvery: SET.longBreakEvery
       });
       break;
     }


### PR DESCRIPTION
## Summary
- add long‑break options to the popup UI
- store long‑break values in chrome storage
- include long‑break settings in `getState`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f24c11de483248f315099ff857d7c