### PR TITLE
Add long break settings

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -20,6 +20,8 @@
     <label>Work (min): <input type="number" id="workMinutes" min="1" value="25"></label>
     <label>Break (min): <input type="number" id="breakMinutes" min="1" value="5"></label>
     <label>Cycles: <input type="number" id="cycles" min="1" value="4"></label>
+    <label>Long break (min): <input type="number" id="longBreakMinutes" min="1" value="15"></label>
+    <label>Long break every (cycles): <input type="number" id="longBreakEvery" min="1" value="4"></label>
     <button id="saveSettings">Save</button>
     <hr>
     <button id="testSound">🔊 Test sound</button>

--- a/popup.js
+++ b/popup.js
@@ -14,12 +14,24 @@ $("reset").addEventListener("click", ()=> chrome.runtime.sendMessage({cmd:"reset
 
 /************ settings load ************/
 chrome.storage.local.get(["settings"], ({settings})=>{
-  if(settings){ $("workMinutes").value=settings.work; $("breakMinutes").value=settings.break; $("cycles").value=settings.cycles; }
+  if(settings){
+    $("workMinutes").value=settings.work;
+    $("breakMinutes").value=settings.break;
+    $("cycles").value=settings.cycles;
+    $("longBreakMinutes").value=settings.longBreak;
+    $("longBreakEvery").value=settings.longBreakEvery;
+  }
 });
 
 /************ save settings ************/
 $("saveSettings").addEventListener("click", ()=>{
-  const settings={ work:+$("workMinutes").value, break:+$("breakMinutes").value, cycles:+$("cycles").value };
+  const settings={
+    work:+$("workMinutes").value,
+    break:+$("breakMinutes").value,
+    cycles:+$("cycles").value,
+    longBreak:+$("longBreakMinutes").value,
+    longBreakEvery:+$("longBreakEvery").value
+  };
   chrome.storage.local.set({settings}, ()=>{
     chrome.runtime.sendMessage({cmd:"settingsUpdated"});
     alert("Saved! New values apply on next reset/start.");

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,5 +1,11 @@
 /***** defaults *****/
-const DEF = { work: 25, break: 5, cycles: 4 };
+const DEF = {
+  work: 25,
+  break: 5,
+  cycles: 4,
+  longBreak: 15,
+  longBreakEvery: 4
+};
 let SET   = { ...DEF };
 
 /***** state *****/
@@ -114,6 +120,8 @@ chrome.runtime.onMessage.addListener((msg, _sender, reply) => {
         running: st.running,
         cycle: st.cycle,
         totalCycles: st.total,
+        longBreak: SET.longBreak,
+        longBreakEvery: SET.longBreakEvery,
         minutes: Math.floor(rem / 60000),
         seconds: Math.floor((rem % 60000) / 1000)
       });


### PR DESCRIPTION
## Summary
- add long-break fields in popup UI
- persist new long break settings
- expose long break settings in service worker's getState reply

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686f24c11de483248f315099ff857d7c