### PR TITLE
Update long break calculation

### DIFF
--- a/service_worker.js
+++ b/service_worker.js
@@ -75,7 +75,7 @@ function transition(now) {
 
     // Determine break length (long or short)
     const long = (st.workDone % SET.longBreakEvery === 0);
-    const mins = long ? SET.longBreak : SET.break;
+    const mins = long ? (SET.longBreakMin ?? SET.longBreak ?? SET.break) : SET.break;
     st.mode = long ? "longBreak" : "break";
     st.end  = now + mins * 60000;
     play("break");


### PR DESCRIPTION
## Summary
- adjust transition logic so long breaks use `SET.longBreakMin` (fallback to existing settings)

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686f31f216008324babb633d84408d31