### PR TITLE
Improve UI for regex toggles

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -15,10 +15,5 @@ body {
   color: #94a3b8; /* slate-400 */
 }
 
-/* Button to toggle regex/name */
-.toggle-regex-button {
-  font-size: 0.75rem;
-  margin-left: 0.25rem;
-  color: #0ea5e9; /* sky-500 */
-}
+
 

--- a/popup.html
+++ b/popup.html
@@ -15,11 +15,11 @@
     <!-- Left Navigation Bar -->
     <nav class="w-1/3 bg-slate-800 text-white p-4 flex flex-col">
       <h1 class="text-lg font-bold mb-6 text-cyan-400">TomatoFocus</h1>
-      <button id="nav-pomodoro" class="nav-button text-left w-full p-2 rounded-md font-semibold">
+      <button id="nav-pomodoro" class="nav-button text-left w-full p-2 rounded-md font-semibold hover:bg-slate-700 hover:text-white transition-colors">
         <!-- 🍅 Pomodoro -->
 		Pomodoro
       </button>
-      <button id="nav-blocker" class="nav-button text-left w-full p-2 rounded-md font-semibold mt-2">
+      <button id="nav-blocker" class="nav-button text-left w-full p-2 rounded-md font-semibold mt-2 hover:bg-slate-700 hover:text-white transition-colors">
         <!-- 🚫 Website Blocker -->
 		Website Block
       </button>

--- a/popup.js
+++ b/popup.js
@@ -153,7 +153,7 @@ document.addEventListener('DOMContentLoaded', () => {
       listItem.className = 'blocked-site-item flex items-center space-x-1';
 
       const siteName = document.createElement('span');
-      siteName.className = 'font-mono text-sm';
+      siteName.className = 'text-sm';
       if (typeof site === 'string') {
         siteName.textContent = site;
       } else {
@@ -187,9 +187,11 @@ document.addEventListener('DOMContentLoaded', () => {
         toggleBtn.addEventListener('click', () => {
           if (siteName.textContent === site.name) {
             siteName.textContent = site.regex;
+            siteName.classList.add('regex-text');
             toggleBtn.textContent = 'name';
           } else {
             siteName.textContent = site.name;
+            siteName.classList.remove('regex-text');
             toggleBtn.textContent = 'regex';
           }
         });

--- a/tailwind.css
+++ b/tailwind.css
@@ -52,6 +52,18 @@
     @apply text-red-500 font-bold hover:text-red-700 transition-colors;
   }
 
+  .nav-button {
+    @apply text-left w-full p-2 rounded-md font-semibold transition-colors hover:bg-slate-700 hover:text-white;
+  }
+
+  .toggle-regex-button {
+    @apply text-xs ml-1 px-1.5 py-0.5 rounded border border-sky-500 text-sky-600 hover:bg-sky-100 transition-colors;
+  }
+
+  .regex-text {
+    @apply font-mono whitespace-nowrap overflow-x-auto inline-block max-w-full;
+  }
+
   .control-button {
     @apply px-5 py-2 rounded-md font-semibold text-white bg-slate-600 hover:bg-slate-700 transition-colors;
   }


### PR DESCRIPTION
## Summary
- style nav buttons with hover colors
- add Tailwind component styles for nav & regex elements
- let regex text use monospaced scrolling container
- clean popup css
- show monospaced regex text only when toggled

## Testing
- `npx --no-install tailwindcss -i ./tailwind.css -o ./tailwind_build.css --minify` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68785f3ec39c8324b2da3a8a47dcd164