### PR TITLE
Enhance blocker UI

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -17,8 +17,8 @@ body {
 
 /* Thin scrollbars with subtle colors */
 ::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
+  width: 0.375rem;
+  height: 0.375rem;
 }
 
 ::-webkit-scrollbar-track {
@@ -27,11 +27,17 @@ body {
 
 ::-webkit-scrollbar-thumb {
   background: #94a3b8; /* slate-400 */
-  border-radius: 3px;
+  border-radius: 0.1875rem;
 }
 
 ::-webkit-scrollbar-thumb:hover {
   background: #64748b; /* slate-500 */
+}
+
+/* Extra slim scrollbar for regex items */
+.slim-scrollbar::-webkit-scrollbar {
+  width: 0.25rem;
+  height: 0.25rem;
 }
 
 .regex-text{
@@ -39,13 +45,20 @@ body {
   white-space:nowrap;
   overflow-x:auto;
   display:block;
-  max-width:90%;
+  max-width:62.5%;
   padding-top:0.15rem;
   padding-bottom:0.05rem;
 }
 
-.regex-item{
+
+.blocked-regex-item{
   padding: calc(var(--spacing) * 1.5);
+}
+
+.blocked-site-item span{
+  max-width:62.5%;
+  display:block;
+  overflow-x:auto;
 }
 
 .mode-toggle-button{
@@ -54,9 +67,43 @@ body {
   padding:0.5rem;
   border-radius:0.375rem;
   transition-property:background-color;
-  transition-duration:150ms
+  transition-duration:150ms;
+  width:4rem;
+  position:relative;
 }
 
 .mode-toggle-button:hover{
   background-color:#cbd5e1
+}
+
+.note-dismiss{
+  margin-left:0.25rem;
+  color:#94a3b8;
+  background:none;
+  border:none;
+  cursor:pointer;
+  font-weight:700;
+}
+.note-dismiss:hover{
+  color:#64748b;
+}
+
+.mode-toggle-button.narrow-font{
+  font-weight:500;
+}
+
+.mode-toggle-button[data-tip]:hover::after{
+  content: attr(data-tip);
+  position:absolute;
+  bottom:100%;
+  left:50%;
+  transform:translateX(-50%);
+  background:#1e293b;
+  color:#fff;
+  font-size:0.625rem;
+  padding:0.125rem 0.25rem;
+  border-radius:0.25rem;
+  white-space:pre-wrap;
+  width:4.5rem;
+  text-align:center;
 }

--- a/popup.html
+++ b/popup.html
@@ -59,7 +59,7 @@
         <h2 class="text-2xl font-bold text-slate-700 mb-4">Website Blocker</h2>
         <div class="mb-4">
           <p class="text-sm text-slate-500 mb-2">Add a domain to block (e.g., "example.com").</p>
-          <p class="blocker-note mb-2">The list below starts with a few default sites. Remove any you don't need.</p>
+          <p class="blocker-note mb-2">The list below starts with a few default sites. Remove any you don't need.<button id="dismiss-note" class="note-dismiss" aria-label="Dismiss">&times;</button></p>
           <div class="flex space-x-2 items-center">
             <input type="text" id="new-site-input" placeholder="e.g., distracting.com" class="flex-grow p-2 border rounded-md focus:ring-2 focus:ring-blue-500 focus:outline-none">
             <button id="input-mode-toggle" class="mode-toggle-button">WWW</button>

--- a/popup.js
+++ b/popup.js
@@ -124,10 +124,20 @@ document.addEventListener('DOMContentLoaded', () => {
   const addSiteButton = $('add-site-button');
   const inputModeToggle = $('input-mode-toggle');
   let regexMode = false;
+  inputModeToggle.dataset.tip = 'web\ndomain';
+  inputModeToggle.classList.add('narrow-font');
+
+  const note = document.querySelector('.blocker-note');
+  const dismissBtn = document.getElementById('dismiss-note');
+  if (dismissBtn) {
+    dismissBtn.addEventListener('click', () => note?.remove());
+  }
 
   inputModeToggle.addEventListener('click', () => {
     regexMode = !regexMode;
     inputModeToggle.textContent = regexMode ? '(.*)' : 'WWW';
+    inputModeToggle.dataset.tip = regexMode ? 'regular\nexpression' : 'web\ndomain';
+    inputModeToggle.classList.toggle('narrow-font', !regexMode);
   });
   const blockedSitesList = $('blocked-sites-list');
 
@@ -197,7 +207,8 @@ document.addEventListener('DOMContentLoaded', () => {
           const showingName = siteName.textContent === site.name;
           siteName.textContent = showingName ? site.regex : site.name;
           siteName.classList.toggle('regex-text', showingName);
-          listItem.classList.toggle('regex-item', showingName);
+          siteName.classList.toggle('slim-scrollbar', showingName);
+          listItem.classList.toggle('blocked-regex-item', showingName);
           toggleBtn.textContent = showingName ? 'name' : 'regex';
         });
         actions.appendChild(toggleBtn);

--- a/tailwind.css
+++ b/tailwind.css
@@ -61,10 +61,11 @@
   }
 
   .regex-text {
-    @apply font-mono text-xs whitespace-nowrap overflow-x-auto block max-w-full px-0.5;
+    @apply font-mono text-xs whitespace-nowrap overflow-x-auto block px-0.5;
+    max-width:62.5%;
   }
 
-  .regex-item {
+  .blocked-regex-item {
     @apply py-1;
   }
 

--- a/tailwind_build.css
+++ b/tailwind_build.css
@@ -491,6 +491,11 @@
     background-color: var(--color-slate-100);
     padding: calc(var(--spacing) * 2);
   }
+  .blocked-site-item span {
+    max-width: 62.5%;
+    overflow-x: auto;
+    display: block;
+  }
   .remove-site-button {
     --tw-font-weight: var(--font-weight-bold);
     font-weight: var(--font-weight-bold);
@@ -547,7 +552,7 @@
   }
   .regex-text {
     display: block;
-    max-width: 100%;
+    max-width: 62.5%;
     overflow-x: auto;
     padding-inline: calc(var(--spacing) * 0.5);
     font-family: var(--font-mono);
@@ -555,7 +560,7 @@
     line-height: var(--tw-leading, var(--text-xs--line-height));
     white-space: nowrap;
   }
-  .regex-item {
+  .blocked-regex-item {
     padding-block: calc(var(--spacing) * 1);
   }
   .mode-toggle-button {
@@ -565,6 +570,8 @@
     padding-block: calc(var(--spacing) * 2);
     --tw-font-weight: var(--font-weight-extrabold);
     font-weight: var(--font-weight-extrabold);
+    width:4rem;
+    position:relative;
     transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
     transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
     transition-duration: var(--tw-duration, var(--default-transition-duration));
@@ -573,6 +580,25 @@
         background-color: var(--color-slate-300);
       }
     }
+  }
+  .mode-toggle-button.narrow-font {
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+  }
+  .mode-toggle-button[data-tip]:hover::after {
+    content: attr(data-tip);
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #1e293b;
+    color: #fff;
+    font-size: 0.625rem;
+    padding: 0.125rem 0.25rem;
+    border-radius: 0.25rem;
+    white-space: pre-wrap;
+    width: 4.5rem;
+    text-align: center;
   }
   .control-button {
     border-radius: var(--radius-md);
@@ -618,6 +644,11 @@
     border-radius: var(--radius-md);
     background-color: var(--color-slate-100);
     padding: calc(var(--spacing) * 2);
+  }
+  .blocked-site-item span {
+    max-width: 62.5%;
+    overflow-x: auto;
+    display: block;
   }
   .remove-site-button {
     --tw-font-weight: var(--font-weight-bold);


### PR DESCRIPTION
## Summary
- rename `.regex-item` to `.blocked-regex-item`
- slim down scrollbars and use rem units
- adjust blocked site text width
- add dismiss button to blocker note
- add width, tooltip and font change for input mode toggle
- allow toggling thinner scrollbars for regex entries

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6879c3d662948324b3ceeef398073de3