### PR TITLE
Adjust fonts for mode toggle buttons

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -3,6 +3,11 @@ body {
   margin: 0;
 }
 
+/* Keep the original font for data tips */
+:root {
+  --datatip-font: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");
+}
+
 /* Style for the active navigation button */
 .nav-button.active {
   background-color: #4f46e5; /* A nice indigo color */
@@ -64,6 +69,7 @@ body {
 .mode-toggle-button{
   background-color:#e2e8f0;
   font-weight:800;
+  font-family:"Trebuchet MS","Arial Narrow",sans-serif;
   padding:0.5rem;
   border-radius:0.375rem;
   transition-property:background-color;
@@ -90,6 +96,15 @@ body {
 
 .mode-toggle-button.narrow-font{
   font-weight:500;
+  letter-spacing:75%;
+  font-stretch:80%;
+}
+
+.mode-toggle-button[data-tip]{
+  font-family:var(--datatip-font);
+  font-weight:800;
+  font-stretch:100%;
+  letter-spacing:normal;
 }
 
 .mode-toggle-button[data-tip]:hover::after{
@@ -100,6 +115,10 @@ body {
   transform:translateX(-50%);
   background:#1e293b;
   color:#fff;
+  font-family:var(--datatip-font);
+  font-weight:800;
+  font-stretch:100%;
+  letter-spacing:normal;
   font-size:0.625rem;
   padding:0.125rem 0.25rem;
   border-radius:0.25rem;

--- a/popup_tailwind.css
+++ b/popup_tailwind.css
@@ -49,6 +49,7 @@
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
     --default-mono-font-family: var(--font-mono);
+    --datatip-font: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");
   }
 }
 @layer base {
@@ -570,6 +571,7 @@
     padding-block: calc(var(--spacing) * 2);
     --tw-font-weight: var(--font-weight-extrabold);
     font-weight: var(--font-weight-extrabold);
+    font-family:"Trebuchet MS","Arial Narrow",sans-serif;
     width:4rem;
     position:relative;
     transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
@@ -584,6 +586,15 @@
   .mode-toggle-button.narrow-font {
     --tw-font-weight: var(--font-weight-medium);
     font-weight: var(--font-weight-medium);
+    letter-spacing: 75%;
+    font-stretch: 80%;
+  }
+
+  .mode-toggle-button[data-tip] {
+    font-family: var(--datatip-font);
+    font-weight: var(--font-weight-extrabold);
+    font-stretch: 100%;
+    letter-spacing: normal;
   }
   .mode-toggle-button[data-tip]:hover::after {
     content: attr(data-tip);
@@ -593,6 +604,10 @@
     transform: translateX(-50%);
     background-color: #1e293b;
     color: #fff;
+    font-family: var(--datatip-font);
+    font-weight: var(--font-weight-extrabold);
+    font-stretch: 100%;
+    letter-spacing: normal;
     font-size: 0.625rem;
     padding: 0.125rem 0.25rem;
     border-radius: 0.25rem;


### PR DESCRIPTION
## Summary
- store the old mode toggle font as `--datatip-font`
- use Trebuchet MS/Arial Narrow for the mode-toggle button
- tune `.mode-toggle-button.narrow-font`
- style `mode-toggle-button[data-tip]` with the preserved font

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688179f8a3c48324b0389ee7a211ab14