### PR TITLE
Add Website Block expandable submenu and Habit Tracker placeholder

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -98,3 +98,42 @@ body {
  * .remove-site-button
  * .nav-button
  */
+
+.list-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.list-button-arrow {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(-135deg);
+  transition: transform 0.15s ease;
+  margin-left: 0.5rem;
+  flex-shrink: 0;
+}
+
+.list-button.expanded .list-button-arrow {
+  transform: rotate(45deg);
+}
+
+.subnav-list {
+  margin-left: 0.5rem;
+}
+
+.subnav-button {
+  background-color: rgba(255, 255, 255, 0.09);
+  font-size: 0.875rem;
+}
+
+.subnav-button:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.subnav-button.active {
+  background-color: var(--color-tomato-midl, #b84c4c);
+  color: white;
+}

--- a/popup.html
+++ b/popup.html
@@ -19,8 +19,20 @@
       <button id="nav-pomodoro" class="nav-button text-left w-full p-2 rounded-md font-semibold transition-colors">
 		Pomodoro
       </button>
-      <button id="nav-blocker" class="nav-button text-left w-full p-2 rounded-md font-semibold mt-2 transition-colors">
-		Website Block
+      <button id="nav-website-block" class="nav-button list-button text-left w-full p-2 rounded-md font-semibold mt-2 transition-colors" aria-expanded="false">
+        <span>Website Block</span>
+        <span class="list-button-arrow" aria-hidden="true"></span>
+      </button>
+      <div id="website-block-list" class="subnav-list hidden mt-1 space-y-1">
+        <button id="nav-sites-list" class="subnav-button text-left w-full p-2 rounded-md font-semibold transition-colors">
+          Sites List
+        </button>
+        <button id="nav-time-schedule" class="subnav-button text-left w-full p-2 rounded-md font-semibold transition-colors">
+          Time Schedule
+        </button>
+      </div>
+      <button id="nav-habit-tracker" class="nav-button text-left w-full p-2 rounded-md font-semibold mt-2 transition-colors">
+		Habit Tracker
       </button>
     </nav>
 
@@ -54,8 +66,8 @@
       </div>
 
       <!-- Website Blocker View -->
-      <div id="blocker-view" class="view hidden">
-        <h2 class="text-2xl font-bold text-slate-700 mb-4">Website Blocker</h2>
+      <div id="sites-list-view" class="view hidden">
+        <h2 class="text-2xl font-bold text-slate-700 mb-4">Sites List</h2>
         <div class="mb-4">
           <p class="text-sm text-slate-500 mb-2">Add a domain to block (e.g., "example.com").</p>
           <p class="blocker-note mb-2">The list below starts with a few default sites. Remove any you don't need.<button id="dismiss-note" class="note-dismiss" aria-label="Dismiss">&times;</button></p>

--- a/popup.js
+++ b/popup.js
@@ -27,59 +27,92 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // --- Tab Navigation ---
   const navPomodoro = $('nav-pomodoro');
-  const navBlocker = $('nav-blocker');
+  const navWebsiteBlock = $('nav-website-block');
+  const websiteBlockList = $('website-block-list');
+  const navSitesList = $('nav-sites-list');
+  const navTimeSchedule = $('nav-time-schedule');
+  const navHabitTracker = $('nav-habit-tracker');
+
   const pomodoroView = $('pomodoro-view');
-  const blockerView = $('blocker-view');
-  const views = [pomodoroView, blockerView];
+  const sitesListView = $('sites-list-view');
+  const views = [pomodoroView, sitesListView];
+
+  function setListButtonExpanded(button, isExpanded) {
+    button.classList.toggle('expanded', isExpanded);
+    button.setAttribute('aria-expanded', String(isExpanded));
+  }
+
+  function toggleWebsiteBlockList(forceExpanded) {
+    const shouldExpand = typeof forceExpanded === 'boolean'
+      ? forceExpanded
+      : websiteBlockList.classList.contains('hidden');
+
+    websiteBlockList.classList.toggle('hidden', !shouldExpand);
+    setListButtonExpanded(navWebsiteBlock, shouldExpand);
+  }
 
   function showView(viewToShow) {
     views.forEach(view => {
       view.classList.add('hidden');
     });
     viewToShow.classList.remove('hidden');
-    
+
     navPomodoro.classList.toggle('active', viewToShow === pomodoroView);
-    navBlocker.classList.toggle('active', viewToShow === blockerView);
+    navSitesList.classList.toggle('active', viewToShow === sitesListView);
   }
 
   navPomodoro.addEventListener('click', () => showView(pomodoroView));
-  navBlocker.addEventListener('click', () => showView(blockerView));
-  
+  navWebsiteBlock.addEventListener('click', () => toggleWebsiteBlockList());
+
+  navSitesList.addEventListener('click', () => {
+    toggleWebsiteBlockList(true);
+    showView(sitesListView);
+  });
+
+  navTimeSchedule.addEventListener('click', () => {
+    // showView(timeScheduleView);
+  });
+
+  navHabitTracker.addEventListener('click', () => {
+    // showView(habitTrackerView);
+  });
+
   // Show Pomodoro view by default
   showView(pomodoroView);
+  toggleWebsiteBlockList(false);
 
 
   // --- Pomodoro Logic (largely unchanged) ---
-  const timerEl = $("timer"), modeEl = $("mode"), startBtn = $("startPause");
-  const longBreakToggle = $("enableLongBreak"), longBreakSettings = $("longBreakSettings");
+  const timerEl = $('timer'), modeEl = $('mode'), startBtn = $('startPause');
+  const longBreakToggle = $('enableLongBreak'), longBreakSettings = $('longBreakSettings');
 
   function updateLongBreakUI() {
     const on = longBreakToggle.checked;
-    longBreakSettings.style.display = on ? "" : "none";
-    longBreakSettings.querySelectorAll("input").forEach(el => (el.disabled = !on));
+    longBreakSettings.style.display = on ? '' : 'none';
+    longBreakSettings.querySelectorAll('input').forEach(el => (el.disabled = !on));
   }
-  longBreakToggle.addEventListener("change", updateLongBreakUI);
+  longBreakToggle.addEventListener('change', updateLongBreakUI);
 
   // Live updates from service worker
-  chrome.runtime.sendMessage({ cmd: "getState" }, refresh);
+  chrome.runtime.sendMessage({ cmd: 'getState' }, refresh);
   chrome.runtime.onMessage.addListener(msg => {
-    if (msg.cmd === "tick") refresh(msg.state);
-    if (msg.cmd === "playSoundPopup") playLocal(msg.sound);
+    if (msg.cmd === 'tick') refresh(msg.state);
+    if (msg.cmd === 'playSoundPopup') playLocal(msg.sound);
   });
 
   // Controls
-  startBtn.addEventListener("click", () => chrome.runtime.sendMessage({ cmd: "toggle" }));
-  $("reset").addEventListener("click", () => chrome.runtime.sendMessage({ cmd: "reset" }));
+  startBtn.addEventListener('click', () => chrome.runtime.sendMessage({ cmd: 'toggle' }));
+  $('reset').addEventListener('click', () => chrome.runtime.sendMessage({ cmd: 'reset' }));
 
   // Settings Load
-  chrome.storage.local.get(["settings"], ({ settings }) => {
+  chrome.storage.local.get(['settings'], ({ settings }) => {
     if (settings) {
-      $("workMinutes").value = settings.work;
-      $("breakMinutes").value = settings.break;
-      $("cycles").value = settings.cycles;
+      $('workMinutes').value = settings.work;
+      $('breakMinutes').value = settings.break;
+      $('cycles').value = settings.cycles;
       longBreakToggle.checked = settings.enableLongBreak ?? false;
-      $("longBreak").value = settings.longBreak ?? 15;
-      $("longBreakEvery").value = settings.longBreakEvery ?? 4;
+      $('longBreak').value = settings.longBreak ?? 15;
+      $('longBreakEvery').value = settings.longBreakEvery ?? 4;
     } else {
       longBreakToggle.checked = false;
     }
@@ -87,23 +120,23 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // Save Settings
-  $("saveSettings").addEventListener("click", () => {
+  $('saveSettings').addEventListener('click', () => {
     const settings = {
-      work: +$("workMinutes").value,
-      break: +$("breakMinutes").value,
-      cycles: +$("cycles").value,
+      work: +$('workMinutes').value,
+      break: +$('breakMinutes').value,
+      cycles: +$('cycles').value,
       enableLongBreak: longBreakToggle.checked,
-      longBreak: +$("longBreak").value,
-      longBreakEvery: +$("longBreakEvery").value
+      longBreak: +$('longBreak').value,
+      longBreakEvery: +$('longBreakEvery').value
     };
     chrome.storage.local.set({ settings }, () => {
-      chrome.runtime.sendMessage({ cmd: "settingsUpdated" });
-      alert("Saved! New values apply on next reset/start.");
+      chrome.runtime.sendMessage({ cmd: 'settingsUpdated' });
+      alert('Saved! New values apply on next reset/start.');
     });
   });
 
   // Test Sound
-  $("testSound").addEventListener("click", () => playLocal("work"));
+  $('testSound').addEventListener('click', () => playLocal('work'));
   function playLocal(sound) {
     new Audio(chrome.runtime.getURL(`sounds/${sound}.mp3`)).play().catch(console.warn);
   }
@@ -111,11 +144,11 @@ document.addEventListener('DOMContentLoaded', () => {
   // Refresh UI
   function refresh(s) {
     if (!s) return;
-    const m = String(s.minutes).padStart(2, "0"), sec = String(s.seconds).padStart(2, "0");
+    const m = String(s.minutes).padStart(2, '0'), sec = String(s.seconds).padStart(2, '0');
     timerEl.textContent = `${m}:${sec}`;
-    const label = s.mode === "longBreak" ? "Long Break" : s.mode.charAt(0).toUpperCase() + s.mode.slice(1);
+    const label = s.mode === 'longBreak' ? 'Long Break' : s.mode.charAt(0).toUpperCase() + s.mode.slice(1);
     modeEl.textContent = `${label} (${s.cycle + 1}/${s.totalCycles})`;
-    startBtn.textContent = s.running ? "Pause" : (s.paused ? "Resume" : "Start");
+    startBtn.textContent = s.running ? 'Pause' : (s.paused ? 'Resume' : 'Start');
   }
 
 
@@ -144,7 +177,7 @@ document.addEventListener('DOMContentLoaded', () => {
   async function renderBlockedSites() {
     const data = await chrome.storage.local.get(['userBlockedSites', 'defaultSites']);
     let userBlockedSites = Array.isArray(data.userBlockedSites) ? data.userBlockedSites : [];
-    let storedDefaults   = Array.isArray(data.defaultSites) ? data.defaultSites : defaultSites;
+    let storedDefaults = Array.isArray(data.defaultSites) ? data.defaultSites : defaultSites;
 
     if (!data.defaultSites) {
       await chrome.storage.local.set({ defaultSites: storedDefaults });


### PR DESCRIPTION
### Motivation
- Turn the former single "Website Block" nav button into an expandable list so users can choose specific blocker-related panels and allow future list-type nav items to behave consistently.
- Add a placeholder for a future "Habit Tracker" feature placed below the Website Block section so expanding the list pushes it down instead of overlapping.

### Description
- Updated `popup.html` to replace the old `nav-blocker` with `nav-website-block` (a `list-button`), added a `website-block-list` container with `nav-sites-list` and `nav-time-schedule` sub-buttons, and added a `nav-habit-tracker` button below; renamed the blocker content pane from `blocker-view` to `sites-list-view` to match the new sub-button semantics.
- Modified `popup.js` to introduce reusable list-button behavior (`setListButtonExpanded`) and a `toggleWebsiteBlockList` helper, wired `nav-website-block` to expand/collapse the submenu, wired `nav-sites-list` to open the existing sites list view, and left `nav-time-schedule` and `nav-habit-tracker` as no-ops with commented placeholders to call future views (`timeScheduleView`, `habitTrackerView`).
- Added CSS in `popup.css` for `.list-button`, `.list-button-arrow`, `.subnav-list`, and `.subnav-button` to render the arrowhead that rotates between collapsed/expanded states and to ensure sub-buttons push lower items down instead of overlapping.

### Testing
- Ran `node --check popup.js` to validate JS syntax, which completed successfully.
- Served the popup via `python3 -m http.server 4173 --bind 0.0.0.0` and ran a Playwright script against `http://127.0.0.1:4173/popup.html` to expand the Website Block submenu and capture a screenshot, which succeeded.
- Verified the modified `popup.html`, `popup.js`, and `popup.css` load together in the served page and that expanding/collapsing the Website Block button toggles the arrow and the submenu visibility as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9246e87cc8324bee39ede26413392)