### PR TITLE
Close settings on save; hide Test Alarm button; lock parent list-button when subnav active

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -112,6 +112,14 @@ body {
   transform: rotate(45deg) scaleY(1);
 }
 
+
+.list-button.locked,
+.list-button:disabled {
+  cursor: default;
+  opacity: 0.7;
+  pointer-events: none;
+}
+
 .subnav-list {
   margin-left: 0.5rem;
 }

--- a/popup.html
+++ b/popup.html
@@ -60,7 +60,8 @@
               <label class="setting-label">After (cycles): <input type="number" id="longBreakEvery" min="1" value="4" class="setting-input"></label>
             </div>
             <button id="saveSettings" class="w-full mt-4 bg-blue-600 text-white py-2 rounded-md hover:bg-blue-700 transition-colors">Save Settings</button>
-            <button id="testSound" class="w-full mt-2 bg-gray-200 py-2 rounded-md hover:bg-gray-300 transition-colors">Test Alarm Sound</button>
+            <!-- Intended for future usage. Keeping this control in markup for later re-enable. -->
+            <button id="testSound" class="hidden w-full mt-2 bg-gray-200 py-2 rounded-md hover:bg-gray-300 transition-colors">Test Alarm Sound</button>
           </div>
         </details>
       </div>

--- a/popup.js
+++ b/popup.js
@@ -51,6 +51,16 @@ document.addEventListener('DOMContentLoaded', () => {
     setListButtonExpanded(navWebsiteBlock, shouldExpand);
   }
 
+  function setWebsiteSubnavActive(activeButton) {
+    [navSitesList, navTimeSchedule].forEach(button => {
+      button.classList.toggle('active', button === activeButton);
+    });
+    const hasActiveSubnav = [navSitesList, navTimeSchedule].some(button => button.classList.contains('active'));
+    navWebsiteBlock.disabled = hasActiveSubnav;
+    navWebsiteBlock.classList.toggle('locked', hasActiveSubnav);
+    navWebsiteBlock.setAttribute('aria-disabled', String(hasActiveSubnav));
+  }
+
   function showView(viewToShow) {
     views.forEach(view => {
       view.classList.add('hidden');
@@ -61,15 +71,23 @@ document.addEventListener('DOMContentLoaded', () => {
     navSitesList.classList.toggle('active', viewToShow === sitesListView);
   }
 
-  navPomodoro.addEventListener('click', () => showView(pomodoroView));
-  navWebsiteBlock.addEventListener('click', () => toggleWebsiteBlockList());
+  navPomodoro.addEventListener('click', () => {
+    showView(pomodoroView);
+    setWebsiteSubnavActive(null);
+  });
+  navWebsiteBlock.addEventListener('click', () => {
+    if (navWebsiteBlock.disabled) return;
+    toggleWebsiteBlockList();
+  });
 
   navSitesList.addEventListener('click', () => {
     toggleWebsiteBlockList(true);
     showView(sitesListView);
+    setWebsiteSubnavActive(navSitesList);
   });
 
   navTimeSchedule.addEventListener('click', () => {
+    setWebsiteSubnavActive(navTimeSchedule);
     // showView(timeScheduleView);
   });
 
@@ -79,6 +97,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Show Pomodoro view by default
   showView(pomodoroView);
+  setWebsiteSubnavActive(null);
   toggleWebsiteBlockList(false);
 
 
@@ -131,11 +150,11 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     chrome.storage.local.set({ settings }, () => {
       chrome.runtime.sendMessage({ cmd: 'settingsUpdated' });
-      alert('Saved! New values apply on next reset/start.');
+      window.close();
     });
   });
 
-  // Test Sound
+  // Intended for future usage when the control is visible again.
   $('testSound').addEventListener('click', () => playLocal('work'));
   function playLocal(sound) {
     new Audio(chrome.runtime.getURL(`sounds/${sound}.mp3`)).play().catch(console.warn);


### PR DESCRIPTION
### Motivation
- Improve settings UX by removing the modal `alert` confirmation and closing the popup after saving so the settings pane no longer requires an extra click to dismiss. 
- Keep the `Test Alarm Sound` control available in code for future re-use while hiding it from the current UI. 
- Prevent accidental interaction with a parent list-button while one of its sub-buttons is selected by making the parent unclickable/visually disabled.

### Description
- Replaced the save confirmation `alert` with `window.close()` in `popup.js` so the popup closes immediately after saving settings. 
- Hid the `Test Alarm Sound` button in `popup.html` by adding a comment and changing the button to use the `hidden` class, and added a comment in `popup.js` next to its event handler to indicate future usage. 
- Added `setWebsiteSubnavActive(activeButton)` in `popup.js` to manage subnav active state, toggle `aria-disabled`, and disable the parent `nav-website-block` when a sub-button is active, and wired this into the navigation click handlers. 
- Added CSS rules in `popup.css` for `.list-button.locked` and `.list-button:disabled` to visually indicate the locked/disabled state and make the element unclickable (`pointer-events: none`, lowered `opacity`). 
- Files changed: `popup.js`, `popup.html`, `popup.css`.

### Testing
- Ran `node --check popup.js` to verify the modified script syntax, which succeeded. 
- Served `popup.html` with `python -m http.server 8000 --bind 0.0.0.0` and captured a Playwright screenshot at `http://127.0.0.1:8000/popup.html` to visually validate the updated UI, which succeeded and produced an artifact. 
- All automated checks used during the change (syntax check and browser screenshot) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b27a51c0388324b0423cfd297fa5ac)