### PR TITLE
Improve regex entry UX for Website Block Sites List

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -84,6 +84,12 @@ body {
   background-color:#cbd5e1
 }
 
+
+.regex-input {
+  background-color: #f7f7cf;
+  font-family: var(--font-mono);
+}
+
 .logoimg{
  /*    width: 80px; */
 	/* height: 80px; */

--- a/popup.css
+++ b/popup.css
@@ -101,6 +101,9 @@ body {
 
 #toggle-regex-button {
   min-height: 2.5rem;
+}
+
+#site-input-row #toggle-regex-button:not(.hidden) {
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/popup.css
+++ b/popup.css
@@ -101,14 +101,18 @@ body {
 
 #site-input-row #input-mode-toggle,
 #site-input-row #add-site-button {
-  width: 6rem;
-  min-width: 6rem;
-  max-width: 6rem;
-  flex: 0 0 6rem;
+  width: 2.5rem;
+  min-width: 2.5rem;
+  max-width: 2.5rem;
+  flex: 0 0 2.5rem;
 }
 
 #toggle-regex-button {
-  min-height: 2.5rem;
+  background-color: #cdf9f9;
+  font-weight:550;
+  min-height: 1.75rem;
+  width: 2.5rem;
+  min-width: 2.5rem;
 }
 
 #site-input-row #toggle-regex-button:not(.hidden) {

--- a/popup.css
+++ b/popup.css
@@ -99,6 +99,14 @@ body {
   flex-basis: 8.5rem;
 }
 
+#site-input-row #input-mode-toggle,
+#site-input-row #add-site-button {
+  width: 6rem;
+  min-width: 6rem;
+  max-width: 6rem;
+  flex: 0 0 6rem;
+}
+
 #toggle-regex-button {
   min-height: 2.5rem;
 }

--- a/popup.css
+++ b/popup.css
@@ -90,6 +90,22 @@ body {
   font-family: var(--font-mono);
 }
 
+
+#site-input-row #new-site-input {
+  min-width: 0;
+}
+
+#site-input-row.regex-mode #new-site-input {
+  flex-basis: 8.5rem;
+}
+
+#toggle-regex-button {
+  min-height: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .logoimg{
  /*    width: 80px; */
 	/* height: 80px; */

--- a/popup.html
+++ b/popup.html
@@ -72,7 +72,7 @@
         <div class="mb-4">
           <p class="text-sm text-slate-500 mb-2"></p>
 		  <p class="blocker-note mb-2">The list below starts with a few default sites. Remove any you don't need.<button id="dismiss-note" class="note-dismiss" aria-label="Dismiss">&times;</button></p>
-          <div class="flex space-x-2 items-center">
+          <div id="site-input-row" class="flex space-x-2 items-center">
             <button id="toggle-regex-button" class="toggle-regex-button hidden" type="button">regex</button>
             <input type="text" id="new-site-input" placeholder="e.g., distracting.com" class="flex-grow p-2 border rounded-md focus:ring-2 focus:ring-blue-500 focus:outline-none">
             <button id="input-mode-toggle" class="mode-toggle-button">WWW</button>

--- a/popup.html
+++ b/popup.html
@@ -73,6 +73,7 @@
           <p class="text-sm text-slate-500 mb-2"></p>
 		  <p class="blocker-note mb-2">The list below starts with a few default sites. Remove any you don't need.<button id="dismiss-note" class="note-dismiss" aria-label="Dismiss">&times;</button></p>
           <div class="flex space-x-2 items-center">
+            <button id="toggle-regex-button" class="toggle-regex-button hidden" type="button">regex</button>
             <input type="text" id="new-site-input" placeholder="e.g., distracting.com" class="flex-grow p-2 border rounded-md focus:ring-2 focus:ring-blue-500 focus:outline-none">
             <button id="input-mode-toggle" class="mode-toggle-button">WWW</button>
             <button id="add-site-button" class="add-site-button">Add</button>

--- a/popup.js
+++ b/popup.js
@@ -179,9 +179,31 @@ document.addEventListener('DOMContentLoaded', () => {
   const newSiteInput = $('new-site-input');
   const addSiteButton = $('add-site-button');
   const inputModeToggle = $('input-mode-toggle');
+  const toggleRegexButton = $('toggle-regex-button');
   let regexMode = false;
+  let regexInputTarget = 'name';
+  let pendingRegexEntry = { name: '', regex: '' };
   inputModeToggle.dataset.tip = 'web\ndomain';
   inputModeToggle.classList.add('narrow-font');
+
+  function syncRegexInputState() {
+    if (!regexMode) {
+      toggleRegexButton.classList.add('hidden');
+      toggleRegexButton.textContent = 'regex';
+      newSiteInput.classList.remove('regex-input');
+      newSiteInput.placeholder = 'e.g., distracting.com';
+      return;
+    }
+
+    toggleRegexButton.classList.remove('hidden');
+    const editingRegex = regexInputTarget === 'regex';
+    toggleRegexButton.textContent = editingRegex ? 'name' : 'regex';
+    newSiteInput.classList.toggle('regex-input', editingRegex);
+    newSiteInput.placeholder = editingRegex
+      ? '^https?:\\/\\/.*zombie.*'
+      : 'e.g., Zombie Sites';
+    newSiteInput.value = editingRegex ? pendingRegexEntry.regex : pendingRegexEntry.name;
+  }
 
   const note = document.querySelector('.blocker-note');
   const dismissBtn = document.getElementById('dismiss-note');
@@ -206,6 +228,25 @@ document.addEventListener('DOMContentLoaded', () => {
     inputModeToggle.textContent = regexMode ? '(.*)' : 'WWW';
     inputModeToggle.dataset.tip = regexMode ? 'regular\nexpression' : 'web\ndomain';
     inputModeToggle.classList.toggle('narrow-font', !regexMode);
+
+    if (regexMode) {
+      pendingRegexEntry = { name: '', regex: '' };
+      regexInputTarget = 'name';
+    } else {
+      pendingRegexEntry = { name: '', regex: '' };
+    }
+
+    newSiteInput.value = '';
+    syncRegexInputState();
+  });
+
+  toggleRegexButton.addEventListener('click', () => {
+    if (!regexMode) return;
+
+    pendingRegexEntry[regexInputTarget] = newSiteInput.value.trim();
+    regexInputTarget = regexInputTarget === 'name' ? 'regex' : 'name';
+    syncRegexInputState();
+    newSiteInput.focus();
   });
   const blockedSitesList = $('blocked-sites-list');
 
@@ -295,7 +336,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let newEntry;
     if (regexMode) {
-      newEntry = { name: newSite, regex: newSite };
+      pendingRegexEntry[regexInputTarget] = newSite;
+      const name = pendingRegexEntry.name.trim();
+      const regex = pendingRegexEntry.regex.trim();
+      if (!name || !regex) {
+        syncRegexInputState();
+        return;
+      }
+      newEntry = { name, regex };
     } else {
       let domain = newSite;
       try {
@@ -311,9 +359,14 @@ document.addEventListener('DOMContentLoaded', () => {
       const newBlockedSites = [...userBlockedSites, newEntry];
       await chrome.storage.local.set({ userBlockedSites: newBlockedSites });
       newSiteInput.value = '';
+      pendingRegexEntry = { name: '', regex: '' };
+      regexInputTarget = 'name';
+      syncRegexInputState();
       renderBlockedSites();
     }
   });
+
+  syncRegexInputState();
 
   // Initial render when popup is opened
   renderBlockedSites();

--- a/popup.js
+++ b/popup.js
@@ -180,6 +180,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const addSiteButton = $('add-site-button');
   const inputModeToggle = $('input-mode-toggle');
   const toggleRegexButton = $('toggle-regex-button');
+  const siteInputRow = $('site-input-row');
   let regexMode = false;
   let regexInputTarget = 'name';
   let pendingRegexEntry = { name: '', regex: '' };
@@ -191,11 +192,13 @@ document.addEventListener('DOMContentLoaded', () => {
       toggleRegexButton.classList.add('hidden');
       toggleRegexButton.textContent = 'regex';
       newSiteInput.classList.remove('regex-input');
+      siteInputRow.classList.remove('regex-mode');
       newSiteInput.placeholder = 'e.g., distracting.com';
       return;
     }
 
     toggleRegexButton.classList.remove('hidden');
+    siteInputRow.classList.add('regex-mode');
     const editingRegex = regexInputTarget === 'regex';
     toggleRegexButton.textContent = editingRegex ? 'name' : 'regex';
     newSiteInput.classList.toggle('regex-input', editingRegex);

--- a/popup.js
+++ b/popup.js
@@ -190,7 +190,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function syncRegexInputState() {
     if (!regexMode) {
       toggleRegexButton.classList.add('hidden');
-      toggleRegexButton.textContent = 'regex';
+      toggleRegexButton.textContent = 'name';
       newSiteInput.classList.remove('regex-input');
       siteInputRow.classList.remove('regex-mode');
       newSiteInput.placeholder = 'e.g., distracting.com';
@@ -200,7 +200,7 @@ document.addEventListener('DOMContentLoaded', () => {
     toggleRegexButton.classList.remove('hidden');
     siteInputRow.classList.add('regex-mode');
     const editingRegex = regexInputTarget === 'regex';
-    toggleRegexButton.textContent = editingRegex ? 'name' : 'regex';
+    toggleRegexButton.textContent = editingRegex ? 'regex' : 'name';
     newSiteInput.classList.toggle('regex-input', editingRegex);
     newSiteInput.placeholder = editingRegex
       ? '^https?:\\/\\/.*zombie.*'
@@ -313,7 +313,7 @@ document.addEventListener('DOMContentLoaded', () => {
       actions.className = 'flex items-center space-x-1';
       if (typeof site !== 'string') {
         const toggleRegexButton = document.createElement('button');
-        toggleRegexButton.textContent = 'regex';
+        toggleRegexButton.textContent = 'name';
         toggleRegexButton.className = 'toggle-regex-button';
         toggleRegexButton.addEventListener('click', () => {
           const showingName = siteName.textContent === site.name;
@@ -321,7 +321,7 @@ document.addEventListener('DOMContentLoaded', () => {
           siteName.classList.toggle('regex-text', showingName);
           siteName.classList.toggle('slim-scrollbar', showingName);
           listItem.classList.toggle('blocked-regex-item', showingName);
-          toggleRegexButton.textContent = showingName ? 'name' : 'regex';
+          toggleRegexButton.textContent = showingName ? 'regex' : 'name';
         });
         actions.appendChild(toggleRegexButton);
       }


### PR DESCRIPTION
### Motivation
- Make the "Website Block" Sites List input support two-field regex items (`name` + `regex`) and provide a clear, discoverable editing flow when regex mode is enabled.
- Let users enter and toggle between the friendly name and the actual regex without losing in-progress text, and visually indicate when the input is being used for a regex.

### Description
- Added a left-side `toggle-regex-button` next to the `new-site-input` in `popup.html` which is hidden by default and shown when regex mode is active (`popup.html`).
- Implemented staged regex-entry state in `popup.js` so the input alternates between editing `site.name` and `site.regex` (drafts are preserved while toggling) and the toggle button switches context (`popup.js`).
- Changed `add` behavior so that in regex mode both staged `name` and `regex` must be provided before creating the `{ name, regex }` entry, and the staged state is reset after a successful add (`popup.js`).
- Added `.regex-input` CSS class and applied it while editing the regex part so `new-site-input` uses a monospaced font and a `#f7f7cf` background, and updated placeholders to `e.g., Zombie Sites` for name and `^https?:\/\/.*zombie.*` for regex (`popup.css`, `popup.js`).

### Testing
- Ran `node --check popup.js` to validate the modified script syntax and it succeeded.
- Launched a simple local server (`python -m http.server 4173`) and used an automated browser script to exercise the Sites List -> regex mode flow and capture a UI screenshot, producing an artifact demonstrating the input styling and toggle behavior.
- A Playwright run initially timed out during navigation attempts but was adjusted and the final automated DOM-driven check succeeded in producing the screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b29124e5b48324b6adfcd6d1c7a475)