### PR TITLE
Settings: add password management UI, validation and locking; refine schedule inputs and tooltips

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -198,8 +198,8 @@ body {
     line-height: var(--tw-leading, var(--text-sm--line-height));
     color: var(--color-slate-600);
   }
-  .setting-input {
-    width: calc(var(--spacing) * 16);
+  .password-input {
+    width: calc(var(--spacing) * 48);
     border-radius: var(--radius-md);
     border-style: var(--tw-border-style);
     border-width: 1px;
@@ -432,7 +432,7 @@ body {
 .password-help:focus-visible::after {
   content: attr(data-tip);
   position: absolute;
-  right: 0;
+  left: -3.5rem;
   bottom: calc(100% + 0.35rem);
   background-color: #1e293b;
   color: #fff;
@@ -468,6 +468,7 @@ body {
 .schedule-input-row > button {
   width: auto;
   max-width: none;
+  margin-bottom: 2.5px;
 }
 
 .password-actions-row {

--- a/popup.css
+++ b/popup.css
@@ -415,3 +415,67 @@ body {
   width: 1rem;
   height: 1rem;
 }
+
+.password-help {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.password-help-icon {
+  width: 0.95rem;
+  height: 0.95rem;
+  opacity: 0.85;
+}
+
+.password-help:hover::after,
+.password-help:focus-visible::after {
+  content: attr(data-tip);
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 0.35rem);
+  background-color: #1e293b;
+  color: #fff;
+  font-family: var(--datatip-font);
+  font-size: 0.7rem;
+  border-radius: 0.25rem;
+  padding: 0.35rem 0.45rem;
+  width: max-content;
+  max-width: 11rem;
+  line-height: 1.25;
+  z-index: 50;
+  white-space: normal;
+}
+
+.password-settings-disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+
+
+.schedule-input-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+}
+
+.schedule-input-row > label,
+.schedule-input-row > button {
+  flex: 1 1 0;
+}
+
+.schedule-input-row > button {
+  width: auto;
+  max-width: none;
+}
+
+.password-actions-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.password-actions-row #save-password {
+  margin-left: auto;
+}

--- a/popup.html
+++ b/popup.html
@@ -96,12 +96,12 @@
         <h2 class="text-2xl font-bold text-slate-700 mb-4">Time Schedule</h2>
         <p id="schedule-note" class="blocker-note mb-2">Here you should add the time intervals when websites should be blocked.<button id="dismiss-schedule-note" class="note-dismiss" aria-label="Dismiss">&times;</button></p>
         <div id="time-interval-error" class="hidden p-2 mb-2 rounded-md bg-red-100 text-red-700 text-sm"></div>
-        <div class="grid grid-cols-2 gap-2 mb-3">
+        <div class="schedule-input-row mb-3">
           <label class="text-sm text-slate-600">From:
-            <input id="time-a-input" type="time" step="600" class="w-quarter p-2 border rounded-md mt-1">
+            <input id="time-a-input" type="time" step="600" class="w-full p-2 border rounded-md mt-1">
           </label>
           <label class="text-sm text-slate-600">To:
-            <input id="time-b-input" type="time" step="600" class="w-quarter p-2 border rounded-md mt-1">
+            <input id="time-b-input" type="time" step="600" class="w-full p-2 border rounded-md mt-1">
           </label>
           <button id="add-time-interval" class="add-site-button">Add</button>
         </div>
@@ -117,12 +117,21 @@
         <label class="flex items-center gap-2 text-sm text-slate-700 mb-3">
           <input id="enable-user-password" type="checkbox">
           Activate user password
+          <span id="password-help" class="password-help hidden" aria-label="Password requirements" tabindex="0">
+            <img src="icons/help-icon.svg" alt="Password rules" class="password-help-icon">
+          </span>
         </label>
         <div id="password-settings" class="space-y-2 hidden">
           <label class="setting-label">Password:
             <input id="user-password-input" type="password" class="setting-input" autocomplete="new-password">
           </label>
-          <button id="save-password" class="add-site-button">Save</button>
+          <div class="password-actions-row">
+            <label class="flex items-center gap-2 text-sm text-slate-600">
+              <input id="show-user-password" type="checkbox">
+              Show password text
+            </label>
+            <button id="save-password" class="add-site-button">Save</button>
+          </div>
         </div>
       </div>
     </main>

--- a/popup.html
+++ b/popup.html
@@ -123,7 +123,7 @@
         </label>
         <div id="password-settings" class="space-y-2 hidden">
           <label class="setting-label">Password:
-            <input id="user-password-input" type="password" class="setting-input" autocomplete="new-password">
+            <input id="user-password-input" type="password" class="password-input" autocomplete="new-password">
           </label>
           <div class="password-actions-row">
             <label class="flex items-center gap-2 text-sm text-slate-600">

--- a/popup.js
+++ b/popup.js
@@ -493,37 +493,116 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // --- Settings page logic ---
   const enableUserPasswordCheckbox = $('enable-user-password');
+  const passwordHelp = $('password-help');
   const passwordSettings = $('password-settings');
   const userPasswordInput = $('user-password-input');
+  const showUserPasswordCheckbox = $('show-user-password');
   const savePasswordButton = $('save-password');
+  const validPassConditions = 'Use 4-24 characters and include at least one letter and one number.';
+
+  function isValidPassword(password) {
+    if (password.length < 4 || password.length > 24) return false;
+    const hasLetter = /[a-z]/i.test(password);
+    const hasDigit = /\d/.test(password);
+    return hasLetter && hasDigit;
+  }
+
+  function resetPasswordUIToDefaultState() {
+    passwordSettings.classList.add('hidden');
+    passwordSettings.classList.remove('password-settings-disabled');
+    passwordHelp.classList.add('hidden');
+    showUserPasswordCheckbox.checked = false;
+    userPasswordInput.type = 'password';
+    userPasswordInput.value = '';
+    enableUserPasswordCheckbox.checked = false;
+    userPasswordInput.disabled = false;
+    showUserPasswordCheckbox.disabled = false;
+    savePasswordButton.disabled = false;
+  }
+
+  function setPasswordInputsLocked(locked, savedPasswordLength = 0) {
+    passwordSettings.classList.toggle('password-settings-disabled', locked);
+    userPasswordInput.disabled = locked;
+    showUserPasswordCheckbox.disabled = locked;
+    savePasswordButton.disabled = locked;
+
+    if (locked) {
+      userPasswordInput.type = 'text';
+      userPasswordInput.value = '●'.repeat(savedPasswordLength);
+      showUserPasswordCheckbox.checked = false;
+      return;
+    }
+
+    userPasswordInput.type = showUserPasswordCheckbox.checked ? 'text' : 'password';
+    userPasswordInput.value = '';
+  }
 
   async function syncPasswordSettingsUI() {
-    const { userPasswordEnabled = false } = await chrome.storage.local.get('userPasswordEnabled');
+    const { userPasswordEnabled = false, userPassword = '' } = await chrome.storage.local.get(['userPasswordEnabled', 'userPassword']);
+    const hasSavedPassword = Boolean(userPasswordEnabled && userPassword);
+
     enableUserPasswordCheckbox.checked = userPasswordEnabled;
     passwordSettings.classList.toggle('hidden', !userPasswordEnabled);
+    passwordHelp.classList.toggle('hidden', !hasSavedPassword);
+    passwordHelp.dataset.tip = validPassConditions;
+
+    showUserPasswordCheckbox.checked = false;
+    setPasswordInputsLocked(hasSavedPassword, userPassword.length);
+
+    if (userPasswordEnabled && !userPassword) {
+      await chrome.storage.local.set({ userPasswordEnabled: false, userPassword: '' });
+      resetPasswordUIToDefaultState();
+    }
   }
 
   enableUserPasswordCheckbox.addEventListener('change', async (event) => {
     const checked = event.target.checked;
     const { userPassword = '' } = await chrome.storage.local.get('userPassword');
 
-    if (!checked && userPassword) {
-      const input = window.prompt('Enter current password to disable password protection:');
-      if (input !== userPassword) {
-        enableUserPasswordCheckbox.checked = true;
+    if (!checked) {
+      const inputActive = !passwordSettings.classList.contains('hidden') && !userPasswordInput.disabled;
+      const typedPassword = userPasswordInput.value.trim();
+
+      if (inputActive && !typedPassword) {
+        await chrome.storage.local.set({ userPasswordEnabled: false, userPassword: '' });
+        resetPasswordUIToDefaultState();
         return;
       }
+
+      if (userPassword) {
+        const input = window.prompt('Enter current password to disable password protection:');
+        if (input !== userPassword) {
+          enableUserPasswordCheckbox.checked = true;
+          return;
+        }
+      }
+
+      await chrome.storage.local.set({ userPasswordEnabled: false, userPassword: '' });
+      resetPasswordUIToDefaultState();
+      return;
     }
 
-    await chrome.storage.local.set({ userPasswordEnabled: checked });
-    passwordSettings.classList.toggle('hidden', !checked);
+    await chrome.storage.local.set({ userPasswordEnabled: true, userPassword: '' });
+    passwordSettings.classList.remove('hidden');
+    passwordHelp.classList.add('hidden');
+    showUserPasswordCheckbox.checked = false;
+    setPasswordInputsLocked(false);
+  });
+
+  showUserPasswordCheckbox.addEventListener('change', () => {
+    userPasswordInput.type = showUserPasswordCheckbox.checked ? 'text' : 'password';
   });
 
   savePasswordButton.addEventListener('click', async () => {
-    const password = userPasswordInput.value;
-    if (!password) return;
+    const password = userPasswordInput.value.trim();
+    if (!password || !isValidPassword(password)) {
+      window.alert(`Invalid password. ${validPassConditions}`);
+      return;
+    }
+
     await chrome.storage.local.set({ userPassword: password, userPasswordEnabled: true });
-    userPasswordInput.value = '';
+    passwordHelp.classList.remove('hidden');
+    setPasswordInputsLocked(true, password.length);
   });
 
   syncRegexInputState();


### PR DESCRIPTION
### Motivation
- Improve the user-password settings UX by adding inline help, validation, and a locked/masked state for stored passwords. 
- Make the time-schedule input row more compact and responsive so inputs scale better in the popup. 

### Description
- Added CSS rules for `.password-help`, `.password-settings-disabled`, `.schedule-input-row`, and `.password-actions-row` to support the new tooltip, disabled/locked styling, and layout changes. 
- Updated `popup.html` to replace the time schedule grid with a `schedule-input-row`, added a password help icon (`#password-help`), and grouped the password controls into a `password-actions-row` with a `#show-user-password` checkbox and the `#save-password` button. 
- Implemented password management logic in `popup.js`, including `isValidPassword`, `resetPasswordUIToDefaultState`, `setPasswordInputsLocked`, and an enhanced `syncPasswordSettingsUI`, plus updated handlers for `enable-user-password`, `show-user-password`, and `save-password` to validate, persist (`chrome.storage.local` keys `userPassword` and `userPasswordEnabled`), mask saved passwords, and show contextual help. 

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b626d84cc48324a855e62400c8ecc2)