### PR TITLE
Add lock/unlock for Website Block editors

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -167,6 +167,75 @@ body {
   margin-left: 0.5rem;
 }
 
+
+.view-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.view-lock-button {
+  width: 0.75rem;
+  height: 0.75rem;
+  min-width: 0.75rem;
+  min-height: 0.75rem;
+  border: none;
+  background-color: transparent;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  margin-top: 0.2rem;
+  position: relative;
+}
+
+.view-lock-button[data-lock-state="locked"] {
+  background-image: url("icons/lock-icon.svg");
+}
+
+.view-lock-button[data-lock-state="unlocked"] {
+  background-image: url("icons/unlock-icon.svg");
+}
+
+.view-lock-button[data-password-active="false"] {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.view-lock-button[data-password-active="true"] {
+  cursor: pointer;
+}
+
+.view-lock-button[data-password-active="false"]:hover::after,
+.view-lock-button[data-password-active="false"]:focus-visible::after {
+  content: attr(data-tip);
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 0.35rem);
+  transform: translateX(-50%);
+  background-color: #1e293b;
+  color: #fff;
+  font-family: var(--datatip-font);
+  font-size: 0.65rem;
+  border-radius: 0.25rem;
+  padding: 0.2rem 0.35rem;
+  white-space: nowrap;
+  z-index: 60;
+}
+
+.locked-input-row {
+  display: none !important;
+}
+
+.locked-list-item {
+  opacity: 0.5;
+}
+
+.locked-list-item .remove-site-button {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
 /* ---- Tailwind @layer components moved here from popup_tailwind.css ---- */
 @layer components {
   .control-button {

--- a/popup.html
+++ b/popup.html
@@ -72,7 +72,10 @@
 
       <!-- Website Blocker View -->
       <div id="sites-list-view" class="view hidden">
-        <h2 class="text-2xl font-bold text-slate-700 mb-4">Sites List</h2>
+        <div class="view-header">
+          <h2 class="text-2xl font-bold text-slate-700 mb-4">Sites List</h2>
+          <button id="site-list-lock-button" class="view-lock-button" type="button" aria-label="Toggle site list lock"></button>
+        </div>
         <div class="mb-4">
           <p class="text-sm text-slate-500 mb-2"></p>
 		  <p class="blocker-note mb-2">The list below starts with a few default sites. Remove any you don't need.<button id="dismiss-note" class="note-dismiss" aria-label="Dismiss">&times;</button></p>
@@ -93,7 +96,10 @@
 
       <!-- Time Schedule View -->
       <div id="time-schedule-view" class="view hidden">
-        <h2 class="text-2xl font-bold text-slate-700 mb-4">Time Schedule</h2>
+        <div class="view-header">
+          <h2 class="text-2xl font-bold text-slate-700 mb-4">Time Schedule</h2>
+          <button id="time-schedule-lock-button" class="view-lock-button" type="button" aria-label="Toggle time schedule lock"></button>
+        </div>
         <p id="schedule-note" class="blocker-note mb-2">Here you should add the time intervals when websites should be blocked.<button id="dismiss-schedule-note" class="note-dismiss" aria-label="Dismiss">&times;</button></p>
         <div id="time-interval-error" class="hidden p-2 mb-2 rounded-md bg-red-100 text-red-700 text-sm"></div>
         <div class="schedule-input-row mb-3">

--- a/popup.js
+++ b/popup.js
@@ -188,6 +188,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const inputModeToggle = $('input-mode-toggle');
   const toggleRegexButton = $('toggle-regex-button');
   const siteInputRow = $('site-input-row');
+  const siteListLockButton = $('site-list-lock-button');
+  const timeScheduleLockButton = $('time-schedule-lock-button');
+  let blockerViewsUnlocked = false;
+  let hasActivePassword = false;
   let regexMode = false;
   let regexInputTarget = 'name';
   let pendingRegexEntry = { name: '', regex: '' };
@@ -213,6 +217,50 @@ document.addEventListener('DOMContentLoaded', () => {
       ? '^www\\..*zombie.*'
       : 'e.g., Zombie Sites';
     newSiteInput.value = editingRegex ? pendingRegexEntry.regex : pendingRegexEntry.name;
+  }
+
+
+  function setLockStateForUI() {
+    const lockState = hasActivePassword && !blockerViewsUnlocked ? 'locked' : 'unlocked';
+    [siteListLockButton, timeScheduleLockButton].forEach(button => {
+      button.dataset.passwordActive = String(hasActivePassword);
+      button.dataset.lockState = lockState;
+      button.dataset.tip = hasActivePassword ? '' : 'unavailable: no password provided';
+      button.setAttribute('aria-disabled', String(!hasActivePassword));
+      button.disabled = false;
+    });
+
+    siteInputRow.classList.toggle('locked-input-row', hasActivePassword && !blockerViewsUnlocked);
+    const scheduleInputRow = document.querySelector('.schedule-input-row');
+    scheduleInputRow?.classList.toggle('locked-input-row', hasActivePassword && !blockerViewsUnlocked);
+
+    document.querySelectorAll('#blocked-sites-list .blocked-site-item, #time-interval-list .blocked-site-item').forEach(item => {
+      item.classList.toggle('locked-list-item', hasActivePassword && !blockerViewsUnlocked);
+    });
+  }
+
+  async function unlockBlockerViews() {
+    const { userPassword = '' } = await chrome.storage.local.get('userPassword');
+    const input = window.prompt('Enter password to unlock editing:');
+    if (input !== userPassword) {
+      window.alert('Incorrect password.');
+      return;
+    }
+
+    blockerViewsUnlocked = true;
+    setLockStateForUI();
+  }
+
+  async function handleLockToggle() {
+    if (!hasActivePassword) return;
+
+    if (blockerViewsUnlocked) {
+      blockerViewsUnlocked = false;
+      setLockStateForUI();
+      return;
+    }
+
+    await unlockBlockerViews();
   }
 
   const note = document.querySelector('.blocker-note');
@@ -336,6 +384,8 @@ document.addEventListener('DOMContentLoaded', () => {
       listItem.appendChild(actions);
       blockedSitesList.appendChild(listItem);
     });
+
+    setLockStateForUI();
   }
 
   addSiteButton.addEventListener('click', async () => {
@@ -430,6 +480,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (!timeIntervals.length) {
       timeIntervalList.innerHTML = '<p class="text-slate-500 text-center">No intervals yet.</p>';
+      setLockStateForUI();
       return;
     }
 
@@ -455,6 +506,8 @@ document.addEventListener('DOMContentLoaded', () => {
       item.appendChild(remove);
       timeIntervalList.appendChild(item);
     });
+
+    setLockStateForUI();
   }
 
   addTimeIntervalBtn.addEventListener('click', async () => {
@@ -552,7 +605,15 @@ document.addEventListener('DOMContentLoaded', () => {
     if (userPasswordEnabled && !userPassword) {
       await chrome.storage.local.set({ userPasswordEnabled: false, userPassword: '' });
       resetPasswordUIToDefaultState();
+      hasActivePassword = false;
+      blockerViewsUnlocked = false;
+      setLockStateForUI();
+      return;
     }
+
+    hasActivePassword = hasSavedPassword;
+    blockerViewsUnlocked = false;
+    setLockStateForUI();
   }
 
   enableUserPasswordCheckbox.addEventListener('change', async (event) => {
@@ -566,6 +627,9 @@ document.addEventListener('DOMContentLoaded', () => {
       if (inputActive && !typedPassword) {
         await chrome.storage.local.set({ userPasswordEnabled: false, userPassword: '' });
         resetPasswordUIToDefaultState();
+        hasActivePassword = false;
+        blockerViewsUnlocked = false;
+        setLockStateForUI();
         return;
       }
 
@@ -579,6 +643,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
       await chrome.storage.local.set({ userPasswordEnabled: false, userPassword: '' });
       resetPasswordUIToDefaultState();
+      hasActivePassword = false;
+      blockerViewsUnlocked = false;
+      setLockStateForUI();
       return;
     }
 
@@ -603,6 +670,26 @@ document.addEventListener('DOMContentLoaded', () => {
     await chrome.storage.local.set({ userPassword: password, userPasswordEnabled: true });
     passwordHelp.classList.remove('hidden');
     setPasswordInputsLocked(true, password.length);
+    hasActivePassword = true;
+    blockerViewsUnlocked = false;
+    setLockStateForUI();
+  });
+
+  siteListLockButton.addEventListener('click', handleLockToggle);
+  timeScheduleLockButton.addEventListener('click', handleLockToggle);
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden' && blockerViewsUnlocked) {
+      blockerViewsUnlocked = false;
+      setLockStateForUI();
+    }
+  });
+
+  window.addEventListener('blur', () => {
+    if (blockerViewsUnlocked) {
+      blockerViewsUnlocked = false;
+      setLockStateForUI();
+    }
   });
 
   syncRegexInputState();


### PR DESCRIPTION
### Motivation
- Provide a simple lock mechanism to protect editing of the Website Blocker lists when a user password is configured, preventing accidental or unauthorized changes to sites and schedule intervals.

### Description
- Add lock buttons to the top-right of the `Sites List` and `Time Schedule` headers with IDs `site-list-lock-button` and `time-schedule-lock-button` and a shared visual wrapper `view-header` in `popup.html`.
- Add styles in `popup.css` for `.view-lock-button` using the provided `icons/lock-icon.svg` and `icons/unlock-icon.svg` at `0.75rem x 0.75rem`, plus disabled tooltip behavior and classes `.locked-input-row` and `.locked-list-item` to hide inputs and dim list rows when locked.
- Implement shared lock state and behavior in `popup.js` including new state variables `hasActivePassword` and `blockerViewsUnlocked`, and helper functions `setLockStateForUI`, `unlockBlockerViews`, and `handleLockToggle` to: default to locked when a password exists, require a password prompt to unlock, hide input rows and disable remove buttons while locked, toggle lock/unlock from either button, and relock on popup blur/visibility loss.
- Wire lock state changes into the existing password flows so saving/disabling/resetting a password updates the lock availability immediately, and ensure `setLockStateForUI` is reapplied after list re-renders.

### Testing
- Ran a syntax check with `node --check popup.js`, which completed successfully.
- Attempted an automated Playwright screenshot to validate the UI, but the headless browser navigation/server connection failed in this environment and the capture did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6aeb6d8908324af704ccbebbfccb1)