### PR TITLE
Add password-based lock toggles for Website Block editing panels

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -460,6 +460,10 @@ body {
   gap: 0.5rem;
 }
 
+.schedule-input-row.hidden {
+  display: none;
+}
+
 .schedule-input-row > label,
 .schedule-input-row > button {
   flex: 1 1 0;
@@ -490,8 +494,8 @@ body {
 
 .content-lock-button {
   position: relative;
-  width: 0.75rem;
-  height: 0.75rem;
+  width: 1.5rem;
+  height: 1.5rem;
   padding: 0;
   border: none;
   background: transparent;
@@ -500,8 +504,8 @@ body {
 }
 
 .content-lock-icon {
-  width: 0.75rem;
-  height: 0.75rem;
+  width: 1.5rem;
+  height: 1.5rem;
   display: block;
 }
 

--- a/popup.css
+++ b/popup.css
@@ -480,3 +480,59 @@ body {
 .password-actions-row #save-password {
   margin-left: auto;
 }
+
+
+.view-header-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.content-lock-button {
+  position: relative;
+  width: 0.75rem;
+  height: 0.75rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.content-lock-icon {
+  width: 0.75rem;
+  height: 0.75rem;
+  display: block;
+}
+
+.content-lock-button.content-lock-button-inactive {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.content-lock-button[data-tip]:not([data-tip='']).content-lock-button-inactive:hover::after {
+  content: attr(data-tip);
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  right: 0;
+  background-color: #1e293b;
+  color: #fff;
+  font-family: var(--datatip-font);
+  font-size: 0.65rem;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.35rem;
+  width: max-content;
+  max-width: 11rem;
+  line-height: 1.25;
+  z-index: 50;
+  white-space: nowrap;
+}
+
+.content-item-locked span {
+  opacity: 0.5;
+}
+
+.content-action-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/popup.html
+++ b/popup.html
@@ -72,7 +72,12 @@
 
       <!-- Website Blocker View -->
       <div id="sites-list-view" class="view hidden">
-        <h2 class="text-2xl font-bold text-slate-700 mb-4">Sites List</h2>
+        <div class="view-header-row mb-4">
+          <h2 class="text-2xl font-bold text-slate-700">Sites List</h2>
+          <button id="sites-list-lock-toggle" class="content-lock-button" type="button" aria-label="Toggle site list lock">
+            <img src="icons/lock-icon.svg" alt="Locked" class="content-lock-icon">
+          </button>
+        </div>
         <div class="mb-4">
           <p class="text-sm text-slate-500 mb-2"></p>
 		  <p class="blocker-note mb-2">The list below starts with a few default sites. Remove any you don't need.<button id="dismiss-note" class="note-dismiss" aria-label="Dismiss">&times;</button></p>
@@ -93,10 +98,15 @@
 
       <!-- Time Schedule View -->
       <div id="time-schedule-view" class="view hidden">
-        <h2 class="text-2xl font-bold text-slate-700 mb-4">Time Schedule</h2>
+        <div class="view-header-row mb-4">
+          <h2 class="text-2xl font-bold text-slate-700">Time Schedule</h2>
+          <button id="time-schedule-lock-toggle" class="content-lock-button" type="button" aria-label="Toggle time schedule lock">
+            <img src="icons/lock-icon.svg" alt="Locked" class="content-lock-icon">
+          </button>
+        </div>
         <p id="schedule-note" class="blocker-note mb-2">Here you should add the time intervals when websites should be blocked.<button id="dismiss-schedule-note" class="note-dismiss" aria-label="Dismiss">&times;</button></p>
         <div id="time-interval-error" class="hidden p-2 mb-2 rounded-md bg-red-100 text-red-700 text-sm"></div>
-        <div class="schedule-input-row mb-3">
+        <div id="schedule-input-row" class="schedule-input-row mb-3">
           <label class="text-sm text-slate-600">From:
             <input id="time-a-input" type="time" step="600" class="w-full p-2 border rounded-md mt-1">
           </label>

--- a/popup.js
+++ b/popup.js
@@ -187,7 +187,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const addSiteButton = $('add-site-button');
   const inputModeToggle = $('input-mode-toggle');
   const toggleRegexButton = $('toggle-regex-button');
-  const siteInputRow = $('site-input-row');
   let regexMode = false;
   let regexInputTarget = 'name';
   let pendingRegexEntry = { name: '', regex: '' };
@@ -336,6 +335,8 @@ document.addEventListener('DOMContentLoaded', () => {
       listItem.appendChild(actions);
       blockedSitesList.appendChild(listItem);
     });
+
+    updateListActionInteractivity();
   }
 
   addSiteButton.addEventListener('click', async () => {
@@ -384,6 +385,82 @@ document.addEventListener('DOMContentLoaded', () => {
   const addTimeIntervalBtn = $('add-time-interval');
   const timeIntervalError = $('time-interval-error');
   const timeIntervalList = $('time-interval-list');
+  const siteInputRow = $('site-input-row');
+  const scheduleInputRow = $('schedule-input-row');
+  const sitesListLockToggle = $('sites-list-lock-toggle');
+  const timeScheduleLockToggle = $('time-schedule-lock-toggle');
+
+  let contentLocked = false;
+  let hasActivePassword = false;
+
+
+  function updateListActionInteractivity() {
+    const items = document.querySelectorAll('#blocked-sites-list .blocked-site-item, #time-interval-list .blocked-site-item');
+    items.forEach(item => item.classList.toggle('content-item-locked', hasActivePassword && contentLocked));
+
+    const removeButtons = document.querySelectorAll('#blocked-sites-list .remove-site-button, #time-interval-list .remove-site-button');
+    removeButtons.forEach(button => {
+      button.disabled = hasActivePassword && contentLocked;
+      button.classList.toggle('content-action-disabled', hasActivePassword && contentLocked);
+    });
+  }
+
+  function syncContentLockUI() {
+    const lockButtons = [sitesListLockToggle, timeScheduleLockToggle];
+    const lockIconPath = contentLocked ? 'icons/lock-icon.svg' : 'icons/unlock-icon.svg';
+    const lockAlt = contentLocked ? 'Locked' : 'Unlocked';
+
+    lockButtons.forEach(button => {
+      if (!button) return;
+      const icon = button.querySelector('img');
+      if (icon) {
+        icon.src = lockIconPath;
+        icon.alt = lockAlt;
+      }
+
+      button.classList.toggle('content-lock-button-inactive', !hasActivePassword);
+      button.setAttribute('aria-disabled', String(!hasActivePassword));
+      button.dataset.tip = hasActivePassword ? '' : 'unavailable: no password provided';
+    });
+
+    siteInputRow?.classList.toggle('hidden', hasActivePassword && contentLocked);
+    scheduleInputRow?.classList.toggle('hidden', hasActivePassword && contentLocked);
+
+    updateListActionInteractivity();
+  }
+
+  async function refreshContentLockAvailability() {
+    const { userPasswordEnabled = false, userPassword = '' } = await chrome.storage.local.get(['userPasswordEnabled', 'userPassword']);
+    hasActivePassword = Boolean(userPasswordEnabled && userPassword);
+
+    if (!hasActivePassword) {
+      contentLocked = false;
+    }
+
+    syncContentLockUI();
+  }
+
+  async function handleContentLockToggle() {
+    if (!hasActivePassword) return;
+
+    if (contentLocked) {
+      const { userPassword = '' } = await chrome.storage.local.get('userPassword');
+      const typed = window.prompt('Enter password to unlock:');
+      if (typed !== userPassword) {
+        window.alert('Incorrect password.');
+        return;
+      }
+      contentLocked = false;
+      syncContentLockUI();
+      return;
+    }
+
+    contentLocked = true;
+    syncContentLockUI();
+  }
+
+  sitesListLockToggle?.addEventListener('click', handleContentLockToggle);
+  timeScheduleLockToggle?.addEventListener('click', handleContentLockToggle);
 
   async function setupScheduleNote() {
     if (!scheduleNote) return;
@@ -430,6 +507,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (!timeIntervals.length) {
       timeIntervalList.innerHTML = '<p class="text-slate-500 text-center">No intervals yet.</p>';
+      updateListActionInteractivity();
       return;
     }
 
@@ -455,6 +533,8 @@ document.addEventListener('DOMContentLoaded', () => {
       item.appendChild(remove);
       timeIntervalList.appendChild(item);
     });
+
+    updateListActionInteractivity();
   }
 
   addTimeIntervalBtn.addEventListener('click', async () => {
@@ -553,6 +633,9 @@ document.addEventListener('DOMContentLoaded', () => {
       await chrome.storage.local.set({ userPasswordEnabled: false, userPassword: '' });
       resetPasswordUIToDefaultState();
     }
+
+    contentLocked = hasSavedPassword;
+    await refreshContentLockAvailability();
   }
 
   enableUserPasswordCheckbox.addEventListener('change', async (event) => {
@@ -566,6 +649,8 @@ document.addEventListener('DOMContentLoaded', () => {
       if (inputActive && !typedPassword) {
         await chrome.storage.local.set({ userPasswordEnabled: false, userPassword: '' });
         resetPasswordUIToDefaultState();
+        contentLocked = false;
+        await refreshContentLockAvailability();
         return;
       }
 
@@ -579,10 +664,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
       await chrome.storage.local.set({ userPasswordEnabled: false, userPassword: '' });
       resetPasswordUIToDefaultState();
+      contentLocked = false;
+      await refreshContentLockAvailability();
       return;
     }
 
     await chrome.storage.local.set({ userPasswordEnabled: true, userPassword: '' });
+    contentLocked = false;
+    await refreshContentLockAvailability();
     passwordSettings.classList.remove('hidden');
     passwordHelp.classList.add('hidden');
     showUserPasswordCheckbox.checked = false;
@@ -603,6 +692,15 @@ document.addEventListener('DOMContentLoaded', () => {
     await chrome.storage.local.set({ userPassword: password, userPasswordEnabled: true });
     passwordHelp.classList.remove('hidden');
     setPasswordInputsLocked(true, password.length);
+    contentLocked = true;
+    await refreshContentLockAvailability();
+  });
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState !== 'visible' && !contentLocked) {
+      contentLocked = true;
+      syncContentLockUI();
+    }
   });
 
   syncRegexInputState();
@@ -612,4 +710,5 @@ document.addEventListener('DOMContentLoaded', () => {
   // Initial render when popup is opened
   renderBlockedSites();
   renderIntervals();
+  refreshContentLockAvailability();
 });


### PR DESCRIPTION
### Motivation
- Prevent accidental or unauthorized edits to the Website Blocker editors (Sites List and Time Schedule) by gating edits behind the user password feature.
- Provide a compact lock UI in the view header so users can lock/unlock editing without navigating away from the panels.
- Ensure locked state hides/folds inputs and disables destructive actions while still showing the lists for inspection.

### Description
- Added header lock controls to the Sites List and Time Schedule views in `popup.html` and added an `id="schedule-input-row"` so the schedule input row can be hidden when locked.
- Added CSS rules in `popup.css` for `.view-header-row`, `.content-lock-button`, `.content-lock-icon`, `.content-lock-button-inactive`, tooltip-on-hover for inactive lock, and visuals for locked items and disabled actions.
- Implemented shared lock logic in `popup.js` with new state variables `contentLocked` and `hasActivePassword`, and helper functions `updateListActionInteractivity()`, `syncContentLockUI()`, `refreshContentLockAvailability()`, and `handleContentLockToggle()` to toggle icons (`icons/lock-icon.svg` / `icons/unlock-icon.svg`), hide input rows, and disable remove buttons when locked.
- Integrated lock availability with the existing password settings flow so locks default to `locked` after saving a password, become inactive/unclickable (with tooltip) when no password is set, prompt for password on unlock attempts, and automatically relock on popup visibility loss; also ensured `renderBlockedSites()` and `renderIntervals()` call the interactivity updater.

### Testing
- Ran `node --check popup.js` to validate the modified script syntax and it passed successfully.
- Attempted a Playwright screenshot to visually validate the popup UI, but the headless browser in this environment failed to load the local server page (`ERR_EMPTY_RESPONSE`), so visual verification was not completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6aeb6d8908324af704ccbebbfccb1)