### PR TITLE
Add local redirect page and make blocker rule installation time-aware and atomic

### DIFF
--- a/redirect-page.css
+++ b/redirect-page.css
@@ -3,8 +3,11 @@
   --bg-start: #4b1e14;
   --bg-end: #37120c;
   --accent: #ff5630;
+  --accent-mid: #ff6a4d;
+  --accent-soft: #ff9e84;
   --text: #f5f5f5;
   --muted: #d6d6d6;
+  --chip: rgba(255, 106, 77, 0.2);
 }
 
 * {
@@ -33,6 +36,19 @@ body {
   padding: 1.5rem;
 }
 
+.tag {
+  display: inline-block;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.68rem;
+  font-weight: 700;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: var(--chip);
+  color: var(--accent-soft);
+  margin-bottom: 0.85rem;
+}
+
 .card {
   width: min(680px, 100%);
   text-align: center;
@@ -55,15 +71,16 @@ body {
 
 h1 {
   margin: 0 0 0.75rem;
-  font-size: clamp(1.8rem, 4.4vw, 3rem);
-  line-height: 1.12;
+  font-size: clamp(1.6rem, 5vw, 2.6rem);
+  line-height: 1.15;
 }
 
 p {
-  margin: 0 auto 1.4rem;
-  max-width: 40ch;
+  margin: 0 auto;
+  max-width: 52ch;
   color: var(--muted);
   line-height: 1.6;
+  font-size: clamp(0.95rem, 2.5vw, 1.1rem);
 }
 
 

--- a/redirect-page.css
+++ b/redirect-page.css
@@ -1,0 +1,78 @@
+:root {
+  color-scheme: dark;
+  --bg-start: #4b1e14;
+  --bg-end: #37120c;
+  --accent: #ff5630;
+  --text: #f5f5f5;
+  --muted: #d6d6d6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  color: var(--text);
+}
+
+body {
+  background:
+    radial-gradient(circle at top, rgba(217, 60, 38, 0.45), transparent 45%),
+    radial-gradient(circle at bottom, rgba(255, 25, 5, 0.5), transparent 45%),
+    linear-gradient(to bottom, var(--bg-start), var(--bg-end));
+}
+
+.page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+}
+
+.card {
+  width: min(680px, 100%);
+  text-align: center;
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  backdrop-filter: blur(3px);
+  border-radius: 18px;
+  padding: 2rem 1.25rem;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+}
+
+.badge {
+  margin: 0 auto 0.75rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #ffd8ca;
+}
+
+h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.8rem, 4.4vw, 3rem);
+  line-height: 1.12;
+}
+
+p {
+  margin: 0 auto 1.4rem;
+  max-width: 40ch;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+
+.dog {
+  width: min(420px, 78vw);
+  height: auto;
+  margin: 0 auto 0.5rem;
+  display: block;
+  filter: drop-shadow(0 18px 45px rgba(0, 0, 0, 0.45));
+  user-select: none;
+  pointer-events: none;
+}

--- a/redirect-page.html
+++ b/redirect-page.html
@@ -9,8 +9,8 @@
 <body>
   <main class="page">
     <section class="card" aria-live="polite">
-      <img class="dog" src="dogtrotting.gif" alt="Trotting dog animation" width="512" height="512" draggable="false" />
-      <div class="badge">site redirected</div>
+      <img class="dog" src="media/dogtrotting.gif" alt="Trotting dog animation" width="512" height="512" draggable="false" />
+      <div class="tag">site redirected</div>
       <h1>Not this one. Back to your goals.</h1>
       <p>
         This page is blocked so future-you has a better shot at getting things done.

--- a/redirect-page.html
+++ b/redirect-page.html
@@ -4,35 +4,18 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Blocked for Now</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="redirect-page.css" />
 </head>
-<body class="min-h-screen bg-tomato-700 text-slate-100 antialiased overflow-hidden">
-  <main class="relative min-h-screen">
-    <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(217,60,38,0.45),transparent_45%),radial-gradient(circle_at_bottom,rgba(255,25,5,0.50),transparent_45%),linear-gradient(to_bottom,rgba(75,30,20,0.92),rgba(55,18,12,0.98))]"></div>
-
-    <section class="relative mx-auto flex min-h-screen max-w-5xl items-center justify-center px-6">
-      <div class="absolute left-1/2 top-[43%] flex w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 flex-col items-center text-center">
-        <img
-          src="media/dogtrotting.gif"
-          alt="Trotting dog animation"
-          width="512"
-          height="512"
-          class="h-72 w-72 sm:h-80 sm:w-80 md:h-[26rem] md:w-[26rem] lg:h-[32rem] lg:w-[32rem] select-none object-contain drop-shadow-[0_18px_45px_rgba(0,0,0,0.45)]"
-          draggable="false"
-        />
-
-        <div class="-mt-6 space-y-3">
-          <p class="text-xs font-semibold uppercase tracking-[0.35em] text-peachcream">site redirected</p>
-          <h1 class="text-3xl font-bold tracking-tight text-white sm:text-4xl md:text-5xl">
-            Not this one. Back to your goals.
-          </h1>
-          <p class="mx-auto max-w-xl text-sm leading-6 text-slate-300 sm:text-base">
-            This page is blocked so future-you has a better shot at getting things done.
-          </p>
-        </div>
-      </div>
+<body>
+  <main class="page">
+    <section class="card" aria-live="polite">
+      <img class="dog" src="dogtrotting.gif" alt="Trotting dog animation" width="512" height="512" draggable="false" />
+      <div class="badge">site redirected</div>
+      <h1>Not this one. Back to your goals.</h1>
+      <p>
+        This page is blocked so future-you has a better shot at getting things done.
+      </p>
     </section>
   </main>
 </body>
 </html>
-

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,6 +1,10 @@
 /***** defaults *****/
 // Default sites are stored by popup.js under `defaultSites` in chrome.storage
 const RULE_ID_BASE = 1000; // avoid collision with future dynamic rules
+const BLOCK_PAGE_PATH = '/redirect-page.html';
+const DEFAULT_TIME_INTERVALS = [{ start: 0, end: 240 }]; // 00:00-04:00
+
+let blockerInstallInFlight = Promise.resolve();
 // chrome.declarativeNetRequest.testMatchOutcome({request: { url: "https://www.youtube.com/", type: "main_frame" }, tabId: -1}, r => console.log(r));
 
 const DEF = { work: 25, break: 5, cycles: 4, longBreak: 15, longBreakEvery: 4, enableLongBreak: true };
@@ -14,7 +18,7 @@ let st = { mode: "work", running: false, end: null, cycle: 0, total: SET.cycles,
 chrome.runtime.onStartup.addListener(init);
 chrome.runtime.onInstalled.addListener(init);
 async function init() {
-  const { settings, state, defaultSites = [], userBlockedSites } = await chrome.storage.local.get(["settings", "state", "defaultSites", "userBlockedSites"]);
+  const { settings, state, defaultSites = [], userBlockedSites, timeIntervals } = await chrome.storage.local.get(["settings", "state", "defaultSites", "userBlockedSites", "timeIntervals"]);
   if (settings) SET = { ...DEF, ...settings };
   if (!SET.enableLongBreak) SET.longBreakEvery = Infinity;
   if (state)    st  = { ...st,  ...state    };
@@ -24,19 +28,23 @@ async function init() {
     await chrome.storage.local.set({ userBlockedSites: Array.isArray(defaultSites) ? [...defaultSites] : [] });
   }
 
+  if (!Array.isArray(timeIntervals) || timeIntervals.length === 0) {
+    await chrome.storage.local.set({ timeIntervals: [...DEFAULT_TIME_INTERVALS] });
+  }
+
   // off-screen doc (for sounds)
   await ensureOffscreen();
   // permanent block rules
-  await installBlockerRules();
+  await scheduleInstallBlockerRules();
 
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area === 'local' && (changes.userBlockedSites || changes.defaultSites || changes.timeIntervals)) {
-      installBlockerRules();
+      scheduleInstallBlockerRules();
     }
   });
 
   setInterval(() => {
-    installBlockerRules();
+    scheduleInstallBlockerRules();
   }, 60000);
 
   // start timer loop
@@ -195,7 +203,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, reply) => {
       break;
     }
     case "timeIntervalsUpdated": {
-      installBlockerRules();
+      scheduleInstallBlockerRules();
       break;
     }
   }
@@ -225,6 +233,17 @@ async function shouldBlockNow() {
   });
 }
 
+function scheduleInstallBlockerRules() {
+  blockerInstallInFlight = blockerInstallInFlight
+    .catch(() => {})
+    .then(() => installBlockerRules())
+    .catch(err => {
+      console.error('[Blocker] failed to update rules', err);
+    });
+
+  return blockerInstallInFlight;
+}
+
 async function installBlockerRules () {
   const isWithinSchedule = await shouldBlockNow();
   if (!isWithinSchedule) {
@@ -246,13 +265,9 @@ async function installBlockerRules () {
     }
   }
   /* ---------------------------------
-     0. Remove *all* existing rules
+     0. Snapshot existing rule IDs
      --------------------------------- */
   const all = await chrome.declarativeNetRequest.getDynamicRules();
-  await chrome.declarativeNetRequest.updateDynamicRules({
-    removeRuleIds: all.map(r => r.id),   // nuke everything
-    addRules: []
-  });
 
   /* ---------------------------------
      1. Build fresh redirect rules
@@ -265,7 +280,7 @@ async function installBlockerRules () {
         id: baseId,
         priority: 1,
         action: { type: 'redirect',
-                  redirect: { url: 'https://www.google.com/' } },
+                  redirect: { extensionPath: BLOCK_PAGE_PATH } },
         condition: {
           urlFilter: `||${entry}^`,
           resourceTypes: ["main_frame", "sub_frame", "stylesheet", "script", "image",
@@ -280,7 +295,7 @@ async function installBlockerRules () {
       id: baseId,
       priority: 1,
       action: { type: 'redirect',
-                redirect: { url: 'https://www.google.com/' } },
+                redirect: { extensionPath: BLOCK_PAGE_PATH } },
       condition: {
         regexFilter: entry.regex,
         resourceTypes: ["main_frame", "sub_frame", "stylesheet", "script", "image",
@@ -291,11 +306,11 @@ async function installBlockerRules () {
   });
 
   /* ---------------------------------
-     2. Add them
+     2. Replace old rules atomically
      --------------------------------- */
   await chrome.declarativeNetRequest.updateDynamicRules({
-    addRules: rules,
-    removeRuleIds: []    // none to remove now
+    removeRuleIds: all.map(r => r.id),
+    addRules: rules
   });
 
   console.log("[Blocker] redirect rules installed:", rules.length);


### PR DESCRIPTION
### Motivation
- Replace the previous Tailwind-based, external-styled block page with a self-contained local static page and stylesheet for a consistent offline experience.
- Redirect blocked navigations to an extension-hosted page instead of an external URL to avoid leaking context and to provide a branded block UI.
- Ensure blocker rules respect user-configured time intervals and avoid concurrent or partial updates when rules are being replaced.

### Description
- Added a new `redirect-page.css` file and simplified `redirect-page.html` to use the local stylesheet and local `dogtrotting.gif` asset, removing the Tailwind CDN dependency and inlined utility classes.
- Introduced `BLOCK_PAGE_PATH` and `DEFAULT_TIME_INTERVALS` and ensured `timeIntervals` is initialized in `chrome.storage.local` when missing.
- Implemented `shouldBlockNow()` to check configured `timeIntervals` and wired storage change listeners and a periodic timer to call `scheduleInstallBlockerRules()` when relevant state changes.
- Reworked rule installation: added `scheduleInstallBlockerRules()` to serialize installs via `blockerInstallInFlight`, snapshot existing dynamic rules and then atomically replace them with new redirect rules that use `redirect.extensionPath` pointing to the local block page.

### Testing
- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7a8b11944832485de1ed19b0f42d1)